### PR TITLE
localization fix: replaced Roboto-Light with Droid in MX-Elementary_sys

### DIFF
--- a/MX-Conkyglass/.conkyt
+++ b/MX-Conkyglass/.conkyt
@@ -1,0 +1,37 @@
+#avoid flicker
+double_buffer yes
+use_xft yes
+xftfont norasi:size=40
+#own window to run simultanious 2 or more conkys
+own_window  yes
+own_window_transparent yes
+own_window_type conky
+own_window_hints undecorated,sticky,skip_taskbar,skip_pager,below 
+
+#borders
+draw_borders no
+
+color0 9FC951
+color1 9FC951
+color2 ffffff
+ 
+draw_shades no
+
+#position
+alignment top_middle
+gap_x 50
+gap_y 30
+
+minimum_size 660 0
+
+
+#behaviour
+update_interval 1
+use_xft yes
+
+own_window_argb_value 0
+own_window_argb_visual no
+own_window_colour 000000
+TEXT
+  ${font norasi:size=100}${time %d}${font}${voffset -40}${time %a}${voffset 50}${offset -60}${font}${time %b}${voffset -85} ${font Loma:size=100}${color2}${voffset}${if_match "pmfix${time %p}" == "pmfix"}${time %k:%M}${else}${time %l:%M}${endif}   ${font}${color}${image ./clockbg.png  -s 910x270 -p -30,-40}
+  ##

--- a/MX-Elementary/MX-Elementary_sys
+++ b/MX-Elementary/MX-Elementary_sys
@@ -25,7 +25,7 @@ gap_y 50
 no_buffers yes
 uppercase no
 cpu_avg_samples 2
-override_utf8_locale no
+#override_utf8_locale no
 
 default_color edf1f6
 color1 2da83b
@@ -42,7 +42,7 @@ ${alignc}${color}${font Quicksand - U:pixelsize=70}${if_match "pmfix${time %p}" 
 
 
 #date
-${offset 100}${color2}${font Roboto-Light:pixelsize=30}${time %A}${font}${goto 275}${voffset -17}${color2}${font Roboto-Light:pixelsize=30}${time %x}${font}
+${offset 100}${color2}${font Droid:pixelsize=30}${time %A}${font}${goto 275}${voffset -17}${color2}${font Droid:pixelsize=30}  ${time %x}${font}
 
 #sys
 ${offset 80}${font Roboto-Light:pixelsize=20}${color3}USED: ${offset 9}${color1}cpu${offset 9}${color}${cpu}%${offset 9}${offset 9}${color1}hdd ${color}${offset 9}$color${fs_used_perc /}%${offset 9}${color1}mem ${offset 9}${color}${memperc}%${offset 9}${offset 9}${font}


### PR DESCRIPTION
works now for about all  locales ;  Droid is a good enough replacement font for Robo-Light and has full UTF-8 support