### PR TITLE
More flexible processor temperature parsing

### DIFF
--- a/MX-Asq/MX-GeekyTowerLogo/conky-harddisks.sh
+++ b/MX-Asq/MX-GeekyTowerLogo/conky-harddisks.sh
@@ -6,18 +6,7 @@
 # This file is released under the terms of the GNU GPL license, version 3 or later.
 #
 
-echo '   ${voffset -5}/:'
-echo '   ${voffset 4}${fs_used /} of ${fs_size /} ${alignr}${fs_bar 8,60 /}'
-echo
-
-# For now only for /home
-if [ "`mount | grep -w \"/home\" | awk '{ print $1 }'`" ]; then
-echo '   ${voffset -5}/home:'
-echo '   ${voffset 4}${fs_used /home} of ${fs_size /home} ${alignr}${fs_bar 8,60 /home}'
-echo
-fi
-
-LANG=C mount | grep "/media" | sed 's/.* on //g' | sed 's/type .*//g' | while read media; do
+LANG=C lsblk | grep 'part /' | awk -F' ' '{print $7}' | while read media; do
 echo '   ${voffset -5}'"$media":
 echo '   ${voffset 4}${fs_used' "$media"'} of ${fs_size' "$media"'} ${alignr}${fs_bar 8,60' "$media}"
 echo ''

--- a/MX-KoO/MX-Full
+++ b/MX-KoO/MX-Full
@@ -73,10 +73,10 @@ ${voffset -13}${alignr}${offset -60}${top_mem mem 4} %
 # CPU
 ${voffset -8}${font Open Sans:Bold:size=10}${color0}CPU ${color EC0100}${hr 3}
 $color${font}${execi 1000 cat /proc/cpuinfo | grep 'model name' | sed -e 's/model name.*: //'| uniq} ${freq_g cpu0}GHz $alignr $cpu%  
-${font}Core 0  ${color3}${execi 4 sensors | grep 'Core 0' | cut -c18-24} ${alignc 60}${color2}${cpubar cpu0}${color}
-${font}Core 1  ${color3}${execi 4 sensors | grep 'Core 1' | cut -c18-24} ${alignc 60}${color2}${cpubar cpu1}${color}
-${font}Core 2  ${color3}${execi 4 sensors | grep 'Core 2' | cut -c18-24} ${alignc 60}${color2}${cpubar cpu2}${color}
-${font}Core 3  ${color3}${execi 4 sensors | grep 'Core 3' | cut -c18-24} ${alignc 60}${color2}${cpubar cpu3}${color}
+${font}Core 0  ${color3}${execi 4 sensors | grep 'Core 0' | awk -F' ' '{print $3}' } ${alignc 60}${color2}${cpubar cpu0}${color}
+${font}Core 1  ${color3}${execi 4 sensors | grep 'Core 1' | awk -F' ' '{print $3}' } ${alignc 60}${color2}${cpubar cpu1}${color}
+${font}Core 2  ${color3}${execi 4 sensors | grep 'Core 2' | awk -F' ' '{print $3}' } ${alignc 60}${color2}${cpubar cpu2}${color}
+${font}Core 3  ${color3}${execi 4 sensors | grep 'Core 3' | awk -F' ' '{print $3}' } ${alignc 60}${color2}${cpubar cpu3}${color}
 
 ${voffset -10}------------------------------------------------- ${font Open Sans:Bold:size=10}${color0}${voffset -2}RAM${color}${font}${voffset -1} ---- ${font Open Sans:Bold:size=10}${color0}${voffset -2}CPU${color}${font}${voffset -1} -
 #${hr 1}


### PR DESCRIPTION
On my computer I get an incorrect display of the CPU temperature obtained by the "**cut ...**" expression using fixed line parameters. Using **awk** allows more flexibility to extract the desired field, and as a result, the temperature is displayed correctly.